### PR TITLE
Add forward-proto-header

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -36,7 +36,8 @@ frontend http-in
     http-request deny if internal public
 <% end %>
 
-    reqadd X-Forwarded-Proto:\ http
+    acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
+    reqadd X-Forwarded-Proto:\ http if ! xfp_exists
 <% end %>
 
 <% if_p("ha_proxy.ssl_pem") do |pem| %>


### PR DESCRIPTION
Hi,

If I want to use only the port 80 as proxy (default) behind an ELB the forwarded proto should be pass, be cause some application can require this proto.

Example : 

ELB 80,443,4433--> 80 Haproxy --> 80 router  --> my app

If I query https://mydomain.com the ELB will give the https as forwarder-proto but haproxy still send http, my app is expecting https so I will send a redirect to https  .... so I will loop.





