### PR TITLE
Fixed issue #11

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -69,3 +69,6 @@ properties:
   ha_proxy.backend_port:
     description: "Listening port for Router"
     default: 80
+  ha_proxy.compress_types:
+    description: "If this property is set, gzip compression will be activated for the mime types named in this property. definition like 'text/html text/plain text/css'"
+    default: ""

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -76,6 +76,10 @@ frontend wss-in
 backend http-routers
     mode http
     balance roundrobin
+    <% if p("ha_proxy.compress_types") != "" %>
+    compression algo gzip
+    compression type <%= p("ha_proxy.compress_types") %>
+    <% end %>
     <% p("ha_proxy.backend_servers").each_with_index do |ip, index| %>
         server node<%= index %> <%= ip %>:<%= p("ha_proxy.backend_port") %> check inter 1000
     <% end %>

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -11,7 +11,7 @@ cd ..
 
 tar xzf haproxy/haproxy-1.5.14.tar.gz
 cd haproxy-1.5.14
-make TARGET=linux2628 USE_OPENSSL=1 USE_STATIC_PCRE=1
+make TARGET=linux2628 USE_OPENSSL=1 USE_STATIC_PCRE=1 USE_ZLIB=1
 mkdir ${BOSH_INSTALL_TARGET}/bin
 cp haproxy ${BOSH_INSTALL_TARGET}/bin/
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,5 +1,5 @@
 ---
 name: haproxy
 files:
-- haproxy/haproxy-1.5.10.tar.gz
+- haproxy/haproxy-1.5.14.tar.gz
 - haproxy/pcre-8.36.tar.gz


### PR DESCRIPTION
It is possible now to enable gzip compression for specific mime types. Therefore set property "ha_proxy.compress_types" to a String like "text/html text/plain text/css"

Also fixed a version conflict between packages/haproxy/packaging and packages/haproxy/spec files