### PR TITLE
Fixed Issue #10

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -11,6 +11,7 @@ templates:
   haproxy_ctl:               bin/haproxy_ctl
   monit_debugger:            bin/monit_debugger
   cert.pem.erb:              config/cert.pem
+  ssl_redirect.map.erb:      config/ssl_redirect.map
   helpers/ctl_setup.sh:      helpers/ctl_setup.sh
   helpers/ctl_utils.sh:      helpers/ctl_utils.sh
   properties.sh.erb:    data/properties.sh

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -34,6 +34,12 @@ properties:
   ha_proxy.enable_4443:
     description: "Enables port 4443 for backwards compatibility with WSS-based apps using the old CF haproxy"
     default: false
+  ha_proxy.https_redirect_domains:
+    description: "For each domain in this array, a HTTPS redirect rule will be put in the config file. Redirect will be applied for all subdomains"
+    default: []
+  ha_proxy.https_redirect_all:
+    description: "If this is set to 'true', a https redirect rule for all http calls will be put in the config file"
+    default: false
   ha_proxy.ssl_ciphers:
     default: ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK
     description: "List of SSL Ciphers that are passed to HAProxy"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -40,6 +40,14 @@ frontend http-in
     reqadd X-Forwarded-Proto:\ http if ! xfp_exists
 <% end %>
 
+<% if p("ha_proxy.https_redirect_all") == true %>
+    redirect scheme https code 301 if !{ ssl_fc }
+<% end %>
+<% unless p("ha_proxy.https_redirect_all") == true %>
+    acl ssl_redirect hdr(host),lower,map_end(/var/vcap/jobs/haproxy/config/ssl_redirect.map,false) -m str true
+    redirect scheme https code 301 if ssl_redirect
+<% end %>
+
 <% if_p("ha_proxy.ssl_pem") do |pem| %>
 frontend https-in
     mode http

--- a/jobs/haproxy/templates/ssl_redirect.map.erb
+++ b/jobs/haproxy/templates/ssl_redirect.map.erb
@@ -1,0 +1,3 @@
+<% p("ha_proxy.https_redirect_domains").each do |domain| %>
+<%= domain %>	true
+<% end %>


### PR DESCRIPTION
Following two options are possible now:
- Set property "ha_proxy.https_redirect_all" to true, redirects all requests to https
- Set property "ha_proxy.https_redirect_domains" to an array of domains, all requests to one of these domains will be redirected to https (including ALL subdomains)

This feature is using map-feature of haproxy to provide a high performance for a high number of domains in the list