### PR TITLE
Added support for forcing headers on requests

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -83,3 +83,6 @@ properties:
   ha_proxy.routed_backend_servers:
     description: "Hash of the URL prefixes -> array of the router IPs acting as the HTTP/TCP backends (should include servers all Availability Zones being used)"
     default: {}
+
+  ha_proxy.headers:
+    description: "Hash of custom headers you wish you have set on each request"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -31,6 +31,15 @@ frontend http-in
     mode http
     bind :80
     default_backend http-routers
+<%
+if_p("ha_proxy.headers") do |headers|
+  headers.each do |header, value|
+%>
+    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+<%
+  end
+end
+%>
 
 <% if p("ha_proxy.internal_only_domains").size > 0 %>
     acl public src 0.0.0.0/0
@@ -64,6 +73,16 @@ frontend https-in
     mode http
     bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     default_backend http-routers
+<%
+if_p("ha_proxy.headers") do |headers|
+  headers.each do |header, value|
+%>
+    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+<%
+  end
+end
+%>
+
 
 <% if p("ha_proxy.internal_only_domains").size > 0 %>
     acl public src 0.0.0.0/0
@@ -88,6 +107,16 @@ frontend wss-in
     mode http
     bind :4443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     default_backend http-routers
+<%
+if_p("ha_proxy.headers") do |headers|
+  headers.each do |header, value|
+%>
+    reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+<%
+  end
+end
+%>
+
 
 <% if p("ha_proxy.internal_only_domains").size > 0 %>
     acl public src 0.0.0.0/0


### PR DESCRIPTION
Added support for having HAProxy set headers on each
HTTP request, based on the `ha_proxy.headers` property.

@shinji62 Can you let me know what you think of this?