### PR TITLE
Added support for multiple ssl certificates

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -5,12 +5,13 @@ description: "The HAProxy server can be used to terminate SSL in front of the Ro
 
 packages:
 - haproxy
+- ttar
 
 templates:
   haproxy.config.erb:        config/haproxy.config
   haproxy_ctl:               bin/haproxy_ctl
   monit_debugger:            bin/monit_debugger
-  cert.pem.erb:              config/cert.pem
+  certs.ttar.erb:            config/certs.ttar
   ssl_redirect.map.erb:      config/ssl_redirect.map
   helpers/ctl_setup.sh:      helpers/ctl_setup.sh
   helpers/ctl_utils.sh:      helpers/ctl_utils.sh
@@ -27,7 +28,7 @@ properties:
     description: "Array of domains for internal-only apps/services (not hostnames for the apps/services)"
     default: []
   ha_proxy.ssl_pem:
-    description: "SSL certificate (PEM file)"
+    description: "SSL certificate (PEM file), or an array of SSL certificates (PEM files)"
     default: ~
   ha_proxy.disable_http:
     description: "Disable port 80 traffic"

--- a/jobs/haproxy/templates/cert.pem.erb
+++ b/jobs/haproxy/templates/cert.pem.erb
@@ -1,1 +1,0 @@
-<%= p("ha_proxy.ssl_pem", "") %>

--- a/jobs/haproxy/templates/certs.ttar.erb
+++ b/jobs/haproxy/templates/certs.ttar.erb
@@ -1,0 +1,14 @@
+<%
+if_p("ha_proxy.ssl_pem") do |pem|
+  if !pem.is_a?(Array)
+    pem = [pem]
+  end
+
+  pem.each_with_index do |cert, i|
+%>
+========================== 0600 /var/vcap/jobs/haproxy/config/ssl/cert-<%= i %>.pem
+<%= cert %>
+<%
+  end
+end
+%>

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -71,7 +71,7 @@ end
 <% if_p("ha_proxy.ssl_pem") do |pem| %>
 frontend https-in
     mode http
-    bind :443 ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    bind :443 ssl crt /var/vcap/jobs/haproxy/config/ssl no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     default_backend http-routers
 <%
 if_p("ha_proxy.headers") do |headers|

--- a/jobs/haproxy/templates/haproxy_ctl
+++ b/jobs/haproxy/templates/haproxy_ctl
@@ -5,6 +5,7 @@ set -e
 
 source /var/vcap/jobs/haproxy/helpers/ctl_setup.sh 'haproxy'
 PATH=/var/vcap/packages/haproxy/bin:$PATH
+export PATH=$PATH:/var/vcap/packges/ttar/bin
 
 NAME=haproxy
 DAEMON=$(which haproxy)
@@ -39,6 +40,12 @@ remove_pid() {
     rmdir "$(dirname "${PID_FILE}")" || :
 }
 
+inflate_certs() {
+	# reconstitute certs based on ttar file
+	mkdir -p ${JOB_DIR}/config/ssl
+	ttar < ${JOB_DIR}/config/certs.ttar
+}
+
 start_haproxy() {
     status_haproxy
     if [ "${RETVAL}" = 0 ]; then
@@ -46,6 +53,7 @@ start_haproxy() {
     else
         RETVAL=0
         ensure_dirs
+        inflate_certs
         echo "$("${TIMESTAMP}"): Starting HAProxy"
         set +e
         "${DAEMON}" -f "${CONFIG}" -D -p "${PID_FILE}" 0<&-

--- a/packages/ttar/packaging
+++ b/packages/ttar/packaging
@@ -1,0 +1,11 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+ # Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+export HOME=/var/vcap
+
+mkdir -p ${BOSH_INSTALL_TARGET}/bin
+cp ttar/ttar ${BOSH_INSTALL_TARGET}/bin
+chmod 0755 ${BOSH_INSTALL_TARGET}/bin/ttar

--- a/packages/ttar/spec
+++ b/packages/ttar/spec
@@ -1,0 +1,5 @@
+---
+name: ttar
+dependencies: []
+files:
+  - ttar/ttar


### PR DESCRIPTION
Added support to provide `haproxy.ssl_pem` as an array
of certs, to enable users to serve multiple https domains through
haproxy. If `haproxy.ssl_pem` is specified as a string, a single
cert is create, the same as before. If it is an array, each element
is treated as a separate cert, which gets loaded into haproxy.