### PR TITLE
rspheaders added

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,3 @@
 # Bug Fixes
 
-- Fixed an issue with the wrong X-Forwarded-Proto value being set for https
+- Added support for response headers in haproxy.

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -92,6 +92,13 @@ properties:
         X-Application-ID: my-custom-header
         MyCustomHeader: 3
 
+  ha_proxy.rsp_headers:
+    description: "Hash of custom headers you wish you have set on each request. Spaces are automatically escaped, but any other haproxy delimiters will need to be escaped manually"
+    example: |
+      rsp_headers:
+        X-Application-ID: my-custom-header
+        MyCustomHeader: 3
+
   ha_proxy.tcp:
     description: "List of mappings to perform tcp-based proxying on. See example for mapping datastructure and keys"
     default: []

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -41,6 +41,16 @@ if_p("ha_proxy.headers") do |headers|
 end
 %>
 
+<%
+if_p("ha_proxy.rsp_headers") do |rsp_headers|
+  rsp_headers.each do |rsp_header, value|
+%>
+    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+<%
+  end
+end
+%>
+
 <% if p("ha_proxy.internal_only_domains").size > 0 %>
     acl public src 0.0.0.0/0
 <% p("ha_proxy.internal_only_domains").each do |domain| %>
@@ -78,6 +88,16 @@ if_p("ha_proxy.headers") do |headers|
   headers.each do |header, value|
 %>
     reqadd <%= header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
+<%
+  end
+end
+%>
+
+<%
+if_p("ha_proxy.rsp_headers") do |rsp_headers|
+  rsp_headers.each do |rsp_header, value|
+%>
+    rspadd <%= rsp_header.gsub(/(?!:\\)( )/, '\ ') %>:\ <%= value.gsub(/(?!:\\) /, '\ ') %>
 <%
   end
 end


### PR DESCRIPTION
Adding support for response headers in haproxy. The default header was supporting only request headers. Hardering parameters like HSTS needs response headers in haproxy