### PR TITLE
Correcting the end tag for http block

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,3 @@
 # Bug Fixes
 
-- Fixed an issuse with frontent http block, so that the disable_http applies to the entier http block
+- Fixed an issue with frontent http block, so that the disable_http applies to the entier http block

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Bug Fixes
+
+- Fixed an issuse with frontent http block, so that the disable_http applies to the entier http block

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -56,7 +56,6 @@ end
 <% end %>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ http if ! xfp_exists
-<% end %>
 
 <% if p("ha_proxy.https_redirect_all") == true %>
     redirect scheme https code 301 if !{ ssl_fc }
@@ -64,6 +63,7 @@ end
 <% unless p("ha_proxy.https_redirect_all") == true %>
     acl ssl_redirect hdr(host),lower,map_end(/var/vcap/jobs/haproxy/config/ssl_redirect.map,false) -m str true
     redirect scheme https code 301 if ssl_redirect
+<% end %>
 <% end %>
 
 <%# HTTPS Frontend %>


### PR DESCRIPTION
#Bugfix

Http Redirect code snippet (https_redirect_all) is outside the disable_http block.
Due to this, it is not possible to disable http interface.
