### PR TITLE
Capability to restrict access to api endpoints.

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+#New Feature
+
+Support to restrict accessibility of api endpoints from a given set if incoming ip address's.
+

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -99,6 +99,15 @@ properties:
         X-Application-ID: my-custom-header
         MyCustomHeader: 3
 
+  ha_proxy.restricted_endpoints: 
+    description: "Array of api endpoints whose accessibility should be restricted from a cidr block(s) as defined the trusted_endpoints_cidrs property"
+    default: []
+    example: ["api.cloudfoundry.com", "login.cloudfoundry.com", "doppler.cloudfoundry.com"]
+  ha_proxy.trusted_endpoint_cidrs: 
+    description: "Space separated cidr blocks for restricted_endpoints"
+    default: 0.0.0.0/0
+
+
   ha_proxy.tcp:
     description: "List of mappings to perform tcp-based proxying on. See example for mapping datastructure and keys"
     default: []

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -27,6 +27,9 @@ properties:
   ha_proxy.internal_only_domains:
     description: "Array of domains for internal-only apps/services (not hostnames for the apps/services)"
     default: []
+  ha_proxy.trusted_domain_cidrs: 
+    description: "Space separated trusted cidr blocks for internal_only_domains"
+    default: 0.0.0.0/0
   ha_proxy.ssl_pem:
     description: "SSL certificate (PEM file), or an array of SSL certificates (PEM files)"
     default: ~
@@ -98,15 +101,6 @@ properties:
       rsp_headers:
         X-Application-ID: my-custom-header
         MyCustomHeader: 3
-
-  ha_proxy.restricted_endpoints: 
-    description: "Array of api endpoints whose accessibility should be restricted from a cidr block(s) as defined the trusted_endpoints_cidrs property"
-    default: []
-    example: ["api.cloudfoundry.com", "login.cloudfoundry.com", "doppler.cloudfoundry.com"]
-  ha_proxy.trusted_endpoint_cidrs: 
-    description: "Space separated cidr blocks for restricted_endpoints"
-    default: 0.0.0.0/0
-
 
   ha_proxy.tcp:
     description: "List of mappings to perform tcp-based proxying on. See example for mapping datastructure and keys"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -29,7 +29,7 @@ properties:
     default: []
   ha_proxy.trusted_domain_cidrs: 
     description: "Space separated trusted cidr blocks for internal_only_domains"
-    default: 0.0.0.0/0
+    default: 0.0.0.0/32
   ha_proxy.ssl_pem:
     description: "SSL certificate (PEM file), or an array of SSL certificates (PEM files)"
     default: ~

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -52,11 +52,11 @@ end
 %>
 
 <% if p("ha_proxy.internal_only_domains").size > 0 %>
-    acl public src 0.0.0.0/0
+    acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
 <% p("ha_proxy.internal_only_domains").each do |domain| %>
     acl internal hdr(Host) -m sub <%= domain %>
 <% end %>
-    http-request deny if internal public
+    http-request deny if internal !private
 <% end %>
 
 <% p('ha_proxy.routed_backend_servers').keys.each do |prefix| %>
@@ -73,14 +73,6 @@ end
 <% unless p("ha_proxy.https_redirect_all") == true %>
     acl ssl_redirect hdr(host),lower,map_end(/var/vcap/jobs/haproxy/config/ssl_redirect.map,false) -m str true
     redirect scheme https code 301 if ssl_redirect
-<% end %>
-
-<% if p("ha_proxy.restricted_endpoints").size > 0 %>
-    acl allowed_endpoint_cidrs src <%= p("ha_proxy.trusted_endpoint_cidrs") %>
-<% p("ha_proxy.restricted_endpoints").each do |endpoint| %>
-    acl <%= endpoint %>_acl hdr(Host) -i <%= endpoint %>
-    http-request deny if  <%= endpoint %>_acl !allowed_endpoint_cidrs
-<% end %>
 <% end %>
 
 <% end %>
@@ -112,13 +104,12 @@ if_p("ha_proxy.rsp_headers") do |rsp_headers|
 end
 %>
 
-
 <% if p("ha_proxy.internal_only_domains").size > 0 %>
-    acl public src 0.0.0.0/0
+    acl private src <%= p("ha_proxy.trusted_domain_cidrs") %>
 <% p("ha_proxy.internal_only_domains").each do |domain| %>
     acl internal hdr(Host) -m sub <%= domain %>
 <% end %>
-    http-request deny if internal public
+    http-request deny if internal !private
 <% end %>
 
 <% p('ha_proxy.routed_backend_servers').keys.each do |prefix| %>
@@ -128,14 +119,6 @@ end
 <% end %>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ https if ! xfp_exists
-
-<% if p("ha_proxy.restricted_endpoints").size > 0 %>
-    acl allowed_endpoint_cidrs src <%= p("ha_proxy.trusted_endpoint_cidrs") %>
-<% p("ha_proxy.restricted_endpoints").each do |endpoint| %>
-    acl <%= endpoint %>_acl hdr(Host) -i <%= endpoint %>
-    http-request deny if  <%= endpoint %>_acl !allowed_endpoint_cidrs
-<% end %>
-<% end %>
 
 <% end %>
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -74,6 +74,15 @@ end
     acl ssl_redirect hdr(host),lower,map_end(/var/vcap/jobs/haproxy/config/ssl_redirect.map,false) -m str true
     redirect scheme https code 301 if ssl_redirect
 <% end %>
+
+<% if p("ha_proxy.restricted_endpoints").size > 0 %>
+    acl allowed_endpoint_cidrs src <%= p("ha_proxy.trusted_endpoint_cidrs") %>
+<% p("ha_proxy.restricted_endpoints").each do |endpoint| %>
+    acl <%= endpoint %>_acl hdr(Host) -i <%= endpoint %>
+    http-request deny if  <%= endpoint %>_acl !allowed_endpoint_cidrs
+<% end %>
+<% end %>
+
 <% end %>
 
 <%# HTTPS Frontend %>
@@ -119,6 +128,15 @@ end
 <% end %>
     acl xfp_exists hdr_cnt(X-Forwarded-Proto) gt 0
     reqadd X-Forwarded-Proto:\ https if ! xfp_exists
+
+<% if p("ha_proxy.restricted_endpoints").size > 0 %>
+    acl allowed_endpoint_cidrs src <%= p("ha_proxy.trusted_endpoint_cidrs") %>
+<% p("ha_proxy.restricted_endpoints").each do |endpoint| %>
+    acl <%= endpoint %>_acl hdr(Host) -i <%= endpoint %>
+    http-request deny if  <%= endpoint %>_acl !allowed_endpoint_cidrs
+<% end %>
+<% end %>
+
 <% end %>
 
 <%# HTTPS Websockets Frontend %>


### PR DESCRIPTION
Use Case:
   In the current haproxy both the cloudfoundry apps and cloudfoundry infrastructure management endpoints (like api, login, blobstore, loggregator) are exposed.

  The cloudfoundry infrastructure management endpoints are used only by cloudfondry administrator, who operates from a pre-defined set of source ip's.

   This feature is to restrict configured api endpoints to be accessible only from a fixed set of source ip's.

1) An acl is created with the src ips
2) Per api endpoint a http request deny is added, to deny the request for that api endpoint if the src ip address is not in the above acl.