### PR TITLE
Corrected path to ssl certs for wss-in

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -127,7 +127,7 @@ end
 <% if p("ha_proxy.enable_4443") == true %>
 frontend wss-in
     mode http
-    bind :4443 ssl crt /var/vcap/jobs/haproxy/ssl no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
+    bind :4443 ssl crt /var/vcap/jobs/haproxy/config/ssl no-sslv3 ciphers <%= p("ha_proxy.ssl_ciphers") %>
     default_backend http-routers
 <%
 if_p("ha_proxy.headers") do |headers|


### PR DESCRIPTION
In various locations, the path to the ssl certs are hardcoded to `/var/vcap/jobs/haproxy/config/ssl`. Only for wss-in the path was missing the config subdir.

Making the path variable might be interesting too, but I don't have time for that right now.